### PR TITLE
Revert "[tidb] skip fail foreign_key test"

### DIFF
--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -20,7 +20,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").first
           assert_equal "testings", fk.from_table
           assert_equal "testing_parents", fk.to_table
@@ -49,7 +49,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
           assert_equal "other_id", fk.primary_key
         end
@@ -58,7 +58,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :parent, foreign_key: { to_table: :testing_parents }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fks = @connection.foreign_keys("testings")
           assert_equal([["testings", "testing_parents", "parent_id"]],
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
@@ -93,7 +92,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testings do |t|
             t.references :testing_parent, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").first
           assert_equal "testings", fk.from_table
           assert_equal "testing_parents", fk.to_table
@@ -116,7 +115,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testings do |t|
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
           assert_equal "other_id", fk.primary_key
         end
@@ -134,7 +133,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, index: true, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_reference :testings, :testing_parent, foreign_key: true
           end
@@ -144,7 +143,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, index: true, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_column :testings, :testing_parent_id
           end
@@ -157,8 +156,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testing_parents do |t|
             t.references :testing, foreign_key: true
           end
-          @connection.remove_reference :testing_parents, :testing, foreign_key: true
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testing_parents").first
           assert_equal "testing_parents", fk.from_table
           assert_equal "testing", fk.to_table
@@ -185,7 +182,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           ActiveRecord::Base.table_name_prefix = "p_"
           migration = CreateDogsMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_equal 1, @connection.foreign_keys("p_dogs").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
@@ -196,7 +192,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           ActiveRecord::Base.table_name_suffix = "_s"
           migration = CreateDogsMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_equal 1, @connection.foreign_keys("dogs_s").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
@@ -209,7 +204,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :parent2, foreign_key: { to_table: :testing_parents }
             t.references :self_join, foreign_key: { to_table: :testings }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fks = @connection.foreign_keys("testings").sort_by(&:column)
 
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }
@@ -223,11 +218,11 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :parent1, foreign_key: { to_table: :testing_parents }
             t.references :parent2, foreign_key: { to_table: :testing_parents }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_reference :testings, :parent1, foreign_key: { to_table: :testing_parents }
           end
-          
+
           fks = @connection.foreign_keys("testings").sort_by(&:column)
 
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }


### PR DESCRIPTION
This pull request reverts commit 665833046a91ad7b50449603b8ac70effcc506d6 since TiDB adapter for ActiveRecord has its own `supports_foreign_key?` via https://github.com/pingcap/activerecord-tidb-adapter/commit/39b384f8 which returns `false` unlike mysql2 adapter does.

### Summary

This reverts commit 665833046a91ad7b50449603b8ac70effcc506d6.

### Other Information

Conflict resolved with this commit https://github.com/pingcap/rails/commit/ca24a45889767a1f2f8e567f009fb4bc65eda604