### PR TITLE
Revert "[tidb] fix ar_schema_test"

### DIFF
--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -155,7 +155,6 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
 
   if ActiveRecord::Base.connection.supports_bulk_alter?
     def test_timestamps_without_null_set_null_to_false_on_change_table_with_bulk
-      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14766") if ENV['tidb'].present?
       ActiveRecord::Schema.define do
         create_table :has_timestamps
 
@@ -206,7 +205,6 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
 
     if ActiveRecord::Base.connection.supports_bulk_alter?
       def test_timestamps_sets_precision_on_change_table_with_bulk
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/14766") if ENV['tidb'].present?
         ActiveRecord::Schema.define do
           create_table :has_timestamps
 


### PR DESCRIPTION
### Summary

This pull request reverts commit c060fc46e02cebd3218f7bdb6db92d7d6d49ee2a  since TiDB adapter for ActiveRecord has its own c060fc46e02cebd3218f7bdb6db92d7d6d49ee2a? via https://github.com/pingcap/activerecord-tidb-adapter/commit/39b384f8 which returns false unlike mysql2 adapter does.

This reverts commit c060fc46e02cebd3218f7bdb6db92d7d6d49ee2a.
