### PR TITLE
Cherry pick from pingcap/rails main branch to pingcap/rails 7-0-stable branch

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Place this in /etc/buildkite-agent/hooks/pre-command
+#
+# Needs to be `chown buildkite-agent` and `chmod +x`
+
+# RVM uses unbound variables and will fail without this
+set +u
+
+source /var/lib/buildkite-agent/.rvm/scripts/rvm

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,15 +5,5 @@ env:
   MYSQL_PORT: 4000
 
 steps:
-  - command: "bundle config set --local path '.bundle' && bundle config mirror.https://rubygems.org https://gems.ruby-china.com  && bundle install"
-    label: "bundle install"
-    
-  - wait
-
-  - command: "bundle config set --local path '.bundle' && bundle config mirror.https://rubygems.org https://gems.ruby-china.com  && bundle install && cd activerecord && bundle exec rake db:mysql:build"
-    label: "build database"
-    
-  - wait
-  
-  - command: "bundle config set --local path '.bundle' && bundle config mirror.https://rubygems.org https://gems.ruby-china.com  && bundle install && cd activerecord && bundle exec rake test:mysql2"
-    label: "run mysql2 test"
+  - command: "tidb_activerecord_testing.sh"
+    label: "Run TiDB ActiveRecord testing"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,4 @@
 env:
-  tidb: 1
   MYSQL_HOST: 127.0.0.1
   MYSQL_USER: root
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 env:
   tidb: 1
-  MYSQL_HOST: 127.0.0.1
+  MYSQL_HOST: localhost
   MYSQL_USER: root
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,19 @@
+env:
+  tidb: 1
+  MYSQL_HOST: 127.0.0.1
+  MYSQL_USER: root
+  MYSQL_PORT: 4000
+
+steps:
+  - command: "bundle config set --local path '.bundle' && bundle config mirror.https://rubygems.org https://gems.ruby-china.com  && bundle install"
+    label: "bundle install"
+    
+  - wait
+
+  - command: "bundle config set --local path '.bundle' && bundle config mirror.https://rubygems.org https://gems.ruby-china.com  && bundle install && cd activerecord && bundle exec rake db:mysql:build"
+    label: "build database"
+    
+  - wait
+  
+  - command: "bundle config set --local path '.bundle' && bundle config mirror.https://rubygems.org https://gems.ruby-china.com  && bundle install && cd activerecord && bundle exec rake test:mysql2"
+    label: "run mysql2 test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,6 @@ env:
   tidb: 1
   MYSQL_HOST: 127.0.0.1
   MYSQL_USER: root
-  MYSQL_PORT: 4000
 
 steps:
   - command: "tidb_activerecord_testing.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 env:
   tidb: 1
-  MYSQL_HOST: localhost
+  MYSQL_HOST: 127.0.0.1
   MYSQL_USER: root
 
 steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Welcome to Rails
 
+## TiDB with ActiveRecord building status
+
+| TiDB         | ActiveRecord             | Build status                                                                                                                                                                       |
+|--------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| TiDB 5.1.0   | ActiveRecord 6-1-stable  | [![Build status](https://badge.buildkite.com/4d749353593a42a42491fa173b8d0cfc6743a02dd892e827e2.svg)](https://buildkite.com/hooopo/tidb-dot-5-1-dot-0-activerecord-dot-6-1-stable) |
+| TiDB nightly | ActiveRecord 6-1-stable  | [![Build status](https://badge.buildkite.com/a286ca7bdf2a031564e9c08ce671ba35a2dd9a1247a4986b3f.svg)](https://buildkite.com/hooopo/tidb-dot-nightly-activerecord-dot-6-1-stable)   |
+| TiDB 5.1.0   | ActiveRecord main branch | [![Build status](https://badge.buildkite.com/a19be43102534c997edfefda9051c462fa91e509abacf24d49.svg)](https://buildkite.com/hooopo/tidb-dot-5-1-dot-0-activerecord-dot-main)       |
+| TiDB nightly | ActiveRecord main branch | [![Build status](https://badge.buildkite.com/1f03803b248db844a88c9167c6a5939a574cd620186b61bba3.svg)](https://buildkite.com/hooopo/tidb-dot-nightly-activerecord-dot-main)         |
+
 ## What's Rails?
 
 Rails is a web-application framework that includes everything needed to

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -204,8 +204,8 @@ namespace :db do
     desc "Build the MySQL test databases"
     task :build do
       config = ARTest.config["connections"]["mysql2"]
-      %x( mysql #{connection_arguments["arunit"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
-      %x( mysql #{connection_arguments["arunit2"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
+      %x( mysql #{connection_arguments["arunit"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4 COLLATE #{config["arunit"]["collation"]}" )
+      %x( mysql #{connection_arguments["arunit2"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4 COLLATE #{config["arunit2"]["collation"]}" )
     end
 
     desc "Drop the MySQL test databases"

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -168,6 +168,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
 
   if ActiveRecord::Base.connection.supports_bulk_alter?
     def test_timestamps_without_null_set_null_to_false_on_change_table_with_bulk
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14766") if ENV['tidb'].present?
       ActiveRecord::Schema.define do
         create_table :has_timestamps
 
@@ -218,6 +219,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
 
     if ActiveRecord::Base.connection.supports_bulk_alter?
       def test_timestamps_sets_precision_on_change_table_with_bulk
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/14766") if ENV['tidb'].present?
         ActiveRecord::Schema.define do
           create_table :has_timestamps
 

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -13,6 +13,10 @@ module ActiveRecord
       @connection = ActiveRecord::Base.connection
     end
 
+    def teardown
+      @connection.execute("DELETE FROM subscribers")
+    end
+
     def test_preventing_writes_predicate
       assert_not_predicate @connection, :preventing_writes?
 
@@ -156,6 +160,7 @@ module ActiveRecord
     def teardown
       clean_up_legacy_connection_handlers
       ActiveRecord.legacy_connection_handling = @old_value
+      @connection.execute("DELETE FROM subscribers")
     end
 
     def test_preventing_writes_predicate_legacy

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -18,6 +18,7 @@ module ActiveRecord
       Book.delete_all
       Event.delete_all
       Post.delete_all
+      @connection.execute("DELETE FROM subscribers") rescue nil
     end
 
     ##

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -77,6 +77,7 @@ module ActiveRecord
     end
 
     def test_indexes
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       idx_name = "accounts_idx"
 
       indexes = @connection.indexes("accounts")
@@ -312,6 +313,7 @@ module ActiveRecord
     end
 
     def test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
+      skip("TiDB issue: https://docs.pingcap.com/tidb/stable/constraints#foreign-key") if ENV['tidb'].present?
       klass_has_fk = Class.new(ActiveRecord::Base) do
         self.table_name = "fk_test_has_fk"
       end
@@ -326,6 +328,7 @@ module ActiveRecord
     end
 
     def test_foreign_key_violations_on_insert_are_translated_to_specific_exception
+      skip("TiDB issue: https://docs.pingcap.com/tidb/stable/constraints#foreign-key") if ENV['tidb'].present?
       error = assert_raises(ActiveRecord::InvalidForeignKey) do
         insert_into_fk_test_has_fk
       end
@@ -334,6 +337,7 @@ module ActiveRecord
     end
 
     def test_foreign_key_violations_on_delete_are_translated_to_specific_exception
+      skip("TiDB issue: https://docs.pingcap.com/tidb/stable/constraints#foreign-key") if ENV['tidb'].present?
       insert_into_fk_test_has_fk fk_id: 1
 
       error = assert_raises(ActiveRecord::InvalidForeignKey) do

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -14,6 +14,12 @@ module ActiveRecord
       @connection.materialize_transactions
     end
 
+    def teardown
+      Book.delete_all
+      Event.delete_all
+      Post.delete_all
+    end
+
     ##
     # PostgreSQL does not support null bytes in strings
     unless current_adapter?(:PostgreSQLAdapter) ||
@@ -124,6 +130,8 @@ module ActiveRecord
     def test_exec_query_returns_an_empty_result
       result = @connection.exec_query "INSERT INTO subscribers(nick) VALUES('me')"
       assert_instance_of(ActiveRecord::Result, result)
+    ensure
+      @connection.execute("DELETE FROM subscribers")
     end
 
     if current_adapter?(:Mysql2Adapter)

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -98,6 +98,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_index_in_bulk_change
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/6347") if ENV['tidb'].present?
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = "ALTER TABLE `people` ADD #{type} INDEX `index_people_on_last_name` (`last_name`)"
       assert_sql(expected) do

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -27,6 +27,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_add_index
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     expected = "CREATE INDEX `index_people_on_last_name` ON `people` (`last_name`)"
     assert_equal expected, add_index(:people, :last_name, length: nil)
 
@@ -159,6 +160,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_remove_timestamps
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
     with_real_execute do
       ActiveRecord::Base.connection.create_table :delete_me do |t|
         t.timestamps null: true

--- a/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/case_sensitivity_test.rb
@@ -8,6 +8,10 @@ class Mysql2CaseSensitivityTest < ActiveRecord::Mysql2TestCase
 
   repair_validations(CollationTest)
 
+  def teardown
+    CollationTest.delete_all
+  end
+
   def test_columns_include_collation_different_from_table
     assert_equal "utf8mb4_bin", CollationTest.columns_hash["string_cs_column"].collation
     assert_equal "utf8mb4_general_ci", CollationTest.columns_hash["string_ci_column"].collation

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -11,7 +11,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     @connection = ActiveRecord::Base.connection
     @connection.create_table :charset_collations, id: { type: :string, collation: "utf8mb4_bin" }, force: true do |t|
       t.string :string_ascii_bin, charset: "ascii", collation: "ascii_bin"
-      t.text :text_ucs2_unicode_ci, charset: "ucs2", collation: "ucs2_unicode_ci"
+      t.text :text_ucs2_unicode_ci, charset: "ucs2", collation: "ucs2_unicode_ci" if ENV['tidb'].blank?
     end
   end
 
@@ -20,18 +20,21 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   end
 
   test "string column with charset and collation" do
+     skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/character-set-and-collation#character-sets-and-collations-supported-by-tidb") if ENV['tidb'].present?
     column = @connection.columns(:charset_collations).find { |c| c.name == "string_ascii_bin" }
     assert_equal :string, column.type
     assert_equal "ascii_bin", column.collation
   end
 
   test "text column with charset and collation" do
+     skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/character-set-and-collation#character-sets-and-collations-supported-by-tidb") if ENV['tidb'].present?
     column = @connection.columns(:charset_collations).find { |c| c.name == "text_ucs2_unicode_ci" }
     assert_equal :text, column.type
     assert_equal "ucs2_unicode_ci", column.collation
   end
 
   test "add column with charset and collation" do
+     skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/character-set-and-collation#character-sets-and-collations-supported-by-tidb") if ENV['tidb'].present?
     @connection.add_column :charset_collations, :title, :string, charset: "utf8mb4", collation: "utf8mb4_bin"
 
     column = @connection.columns(:charset_collations).find { |c| c.name == "title" }
@@ -40,6 +43,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   end
 
   test "change column with charset and collation" do
+     skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/character-set-and-collation#character-sets-and-collations-supported-by-tidb") if ENV['tidb'].present?
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :text, charset: "utf8mb4", collation: "utf8mb4_general_ci"
 
@@ -49,6 +53,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   end
 
   test "schema dump includes collation" do
+    skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/character-set-and-collation#character-sets-and-collations-supported-by-tidb") if ENV['tidb'].present?
     output = dump_table_schema("charset_collations")
     assert_match %r/create_table "charset_collations", id: { type: :string, collation: "utf8mb4_bin" }/, output
     assert_match %r{t\.string\s+"string_ascii_bin",\s+collation: "ascii_bin"$}, output

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -29,6 +29,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+
   def test_no_automatic_reconnection_after_timeout
     assert_predicate @connection, :active?
     @connection.update("set @@wait_timeout=1")
@@ -94,6 +95,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_character_set_connection_is_configured
+    skip("TiDB issue: https://docs.pingcap.com/tidb/stable/character-set-and-collation#character-set-and-collation") if ENV['tidb'].present?
     run_without_connection do |orig_connection|
       configuration_hash = orig_connection.except(:encoding, :collation)
       ActiveRecord::Base.establish_connection(configuration_hash.merge!(encoding: "cp932"))
@@ -110,6 +112,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_collation_connection_is_configured
+    skip("TiDB issue: https://docs.pingcap.com/tidb/stable/character-set-and-collation#character-set-and-collation") if ENV['tidb'].present?
     assert_equal "utf8mb4_unicode_ci", @connection.show_variable("collation_connection")
     assert_equal 1, @connection.query_value("SELECT 'こんにちは' = 'コンニチハ'")
 
@@ -199,6 +202,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_get_and_release_advisory_lock
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
     lock_name = "test lock'n'name"
 
     got_lock = @connection.get_advisory_lock(lock_name)
@@ -214,6 +218,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_release_non_existent_advisory_lock
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
     lock_name = "fake lock'n'name"
     released_non_existent_lock = @connection.release_advisory_lock(lock_name)
     assert_equal released_non_existent_lock, false,

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_prevent_writes_test.rb
@@ -50,7 +50,7 @@ class Mysql2AdapterPreventWritesTest < ActiveRecord::Mysql2TestCase
 
   def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
-
+    skip("TiDB issue, TODO") if ENV['tidb'].present?
     ActiveRecord::Base.while_preventing_writes do
       assert_equal 1, @conn.execute("SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594'").entries.count
     end
@@ -82,7 +82,7 @@ class Mysql2AdapterPreventWritesTest < ActiveRecord::Mysql2TestCase
 
   def test_doesnt_error_when_a_read_query_with_leading_chars_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
-
+    skip("TiDB issue, TODO") if ENV['tidb'].present?
     ActiveRecord::Base.while_preventing_writes do
       assert_equal 1, @conn.execute("/*action:index*/(\n( SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594' ) )").entries.count
     end
@@ -156,7 +156,7 @@ class Mysql2AdapterPreventWritesLegacyTest < ActiveRecord::Mysql2TestCase
 
   def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
-
+    skip("TiDB issue, TODO") if ENV['tidb'].present?
     @connection_handler.while_preventing_writes do
       assert_equal 1, @conn.execute("SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594'").entries.count
     end
@@ -188,7 +188,7 @@ class Mysql2AdapterPreventWritesLegacyTest < ActiveRecord::Mysql2TestCase
 
   def test_doesnt_error_when_a_read_query_with_leading_chars_is_called_while_preventing_writes
     @conn.execute("INSERT INTO `engines` (`car_id`) VALUES ('138853948594')")
-
+    skip("TiDB issue, TODO") if ENV['tidb'].present?
     @connection_handler.while_preventing_writes do
       assert_equal 1, @conn.execute("/*action:index*/(\n( SELECT `engines`.* FROM `engines` WHERE `engines`.`car_id` = '138853948594' ) )").entries.count
     end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -102,7 +102,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_errors_for_bigint_fks_on_integer_pk_table_in_alter_table
     # table old_cars has primary key of integer
-
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
     error = assert_raises(ActiveRecord::MismatchedForeignKey) do
       @conn.add_reference :engines, :old_car
       @conn.add_foreign_key :engines, :old_cars
@@ -123,7 +123,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_errors_for_bigint_fks_on_integer_pk_table_in_create_table
     # table old_cars has primary key of integer
-
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
     error = assert_raises(ActiveRecord::MismatchedForeignKey) do
       @conn.execute(<<~SQL)
         CREATE TABLE activerecord_unittest.foos (
@@ -150,7 +150,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_errors_for_integer_fks_on_bigint_pk_table_in_create_table
     # table old_cars has primary key of bigint
-
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
     error = assert_raises(ActiveRecord::MismatchedForeignKey) do
       @conn.execute(<<~SQL)
         CREATE TABLE activerecord_unittest.foos (
@@ -177,7 +177,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_errors_for_bigint_fks_on_string_pk_table_in_create_table
     # table old_cars has primary key of string
-
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
     error = assert_raises(ActiveRecord::MismatchedForeignKey) do
       @conn.execute(<<~SQL)
         CREATE TABLE activerecord_unittest.foos (

--- a/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
@@ -34,6 +34,7 @@ module ActiveRecord
     end
 
     test "deadlock correctly raises Deadlocked inside nested SavepointTransaction" do
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
       assert_raises(ActiveRecord::Deadlocked) do
         barrier = Concurrent::CyclicBarrier.new(2)
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -3,9 +3,11 @@
 require "cases/helper"
 
 class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
+
   self.use_transactional_tests = false
 
   def test_renaming_index_on_foreign_key
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
     connection.add_index "engines", "car_id"
     connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -7,14 +7,14 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
   self.use_transactional_tests = false
 
   def test_renaming_index_on_foreign_key
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     connection.add_index "engines", "car_id"
     connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
 
     connection.rename_index("engines", "index_engines_on_car_id", "idx_renamed")
     assert_equal ["idx_renamed"], connection.indexes("engines").map(&:name)
   ensure
-    connection.remove_foreign_key :engines, name: "fk_engines_cars"
+    connection.remove_foreign_key :engines, name: "fk_engines_cars" rescue nil
   end
 
   def test_initializes_schema_migrations_for_encoding_utf8mb4

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -71,6 +71,7 @@ module ActiveRecord
       end
 
       def test_dump_indexes
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         index_a_name = "index_key_tests_on_snack"
         index_b_name = "index_key_tests_on_pizza"
         index_c_name = "index_key_tests_on_awesome"

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -6,8 +6,7 @@ require "models/comment"
 
 module ActiveRecord
   module ConnectionAdapters
-l
-]k    class Mysql2SchemaTest < ActiveRecord::Mysql2TestCase
+    class Mysql2SchemaTest < ActiveRecord::Mysql2TestCase
       fixtures :posts
 
       def setup

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -6,7 +6,8 @@ require "models/comment"
 
 module ActiveRecord
   module ConnectionAdapters
-    class Mysql2SchemaTest < ActiveRecord::Mysql2TestCase
+l
+]k    class Mysql2SchemaTest < ActiveRecord::Mysql2TestCase
       fixtures :posts
 
       def setup
@@ -121,6 +122,7 @@ class Mysql2AnsiQuotesTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_foreign_keys_method_with_ansi_quotes
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
     fks = @connection.foreign_keys("lessons_students")
     assert_equal([["lessons_students", "students", :cascade]],
                  fks.map { |fk| [fk.from_table, fk.to_table, fk.on_delete] })

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -95,6 +95,7 @@ module ActiveRecord
 
       unless mysql_enforcing_gtid_consistency?
         def test_drop_temporary_table
+          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26278") if ENV['tidb'].present?
           @connection.transaction do
             @connection.create_table(:temp_table, temporary: true)
             # if it doesn't properly say DROP TEMPORARY TABLE, the transaction commit

--- a/activerecord/test/cases/adapters/mysql2/sp_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sp_test.rb
@@ -19,18 +19,21 @@ class Mysql2StoredProcedureTest < ActiveRecord::Mysql2TestCase
   # In MySQL 5.6, CLIENT_MULTI_RESULTS is enabled by default.
   # https://dev.mysql.com/doc/refman/en/call.html
   def test_multi_results
+    skip 'TiDB Issue procedure not support: https://docs.pingcap.com/tidb/stable/mysql-compatibility#unsupported-features'
     rows = @connection.select_rows("CALL ten();")
     assert_equal 10, rows[0][0].to_i, "ten() did not return 10 as expected: #{rows.inspect}"
     assert @connection.active?, "Bad connection use by 'Mysql2Adapter.select_rows'"
   end
 
   def test_multi_results_from_select_one
+    skip 'TiDB Issue procedure not support: https://docs.pingcap.com/tidb/stable/mysql-compatibility#unsupported-features'
     row = @connection.select_one("CALL topics(1);")
     assert_equal "David", row["author_name"]
     assert @connection.active?, "Bad connection use by 'Mysql2Adapter.select_one'"
   end
 
   def test_multi_results_from_find_by_sql
+    skip 'TiDB Issue procedure not support: https://docs.pingcap.com/tidb/stable/mysql-compatibility#unsupported-features'
     topics = Topic.find_by_sql "CALL topics(3);"
     assert_equal 3, topics.size
     assert @connection.active?, "Bad connection use by 'Mysql2Adapter.select'"

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -7,6 +7,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 
+
   def setup
     @connection = ActiveRecord::Base.connection
   end
@@ -18,11 +19,13 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   test "table options with ENGINE" do
     @connection.create_table "mysql_table_options", force: true, options: "ENGINE=MyISAM"
     output = dump_table_schema("mysql_table_options")
+    skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/mysql-compatibility#storage-engines") if ENV['tidb'].present?
     expected = /create_table "mysql_table_options", charset: "utf8mb4"(?:, collation: "\w+")?, options: "ENGINE=MyISAM", force: :cascade/
     assert_match expected, output
   end
 
   test "table options with ROW_FORMAT" do
+    skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/mysql-compatibility#storage-engines") if ENV['tidb'].present?
     @connection.create_table "mysql_table_options", force: true, options: "ROW_FORMAT=REDUNDANT"
     output = dump_table_schema("mysql_table_options")
     expected = /create_table "mysql_table_options", charset: "utf8mb4"(?:, collation: "\w+")?, options: "ENGINE=InnoDB ROW_FORMAT=REDUNDANT", force: :cascade/
@@ -30,6 +33,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   end
 
   test "table options with CHARSET" do
+    skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/mysql-compatibility#storage-engines") if ENV['tidb'].present?
     @connection.create_table "mysql_table_options", force: true, options: "CHARSET=latin1"
     output = dump_table_schema("mysql_table_options")
     expected = /create_table "mysql_table_options", charset: "latin1", force: :cascade/
@@ -51,6 +55,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   end
 
   test "charset and partitioned table options" do
+    skip("TiDB issue: https://docs.pingcap.com/tidb/v5.0/mysql-compatibility#storage-engines") if ENV['tidb'].present?
     @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */", force: :cascade do |t|
       t.bigint "id", null: false, auto_increment: true
       t.bigint "account_id", null: false, unsigned: true

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -60,7 +60,11 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "(?:UPPER|UCASE)\(`name`\)"$/i, output)
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
-      assert_match(/t\.virtual\s+"profile_email",\s+type: :string,\s+as: "json_extract\(`profile`,\w*?'\$\.email'\)", stored: true$/i, output)
+      if ENV['tidb'].present?
+        assert_match(/t\.virtual\s+"profile_email",\s+type: :string,\s+as: "json_extract\(`profile`, \w*?'\$\.email'\)", stored: true$/i, output)
+      else
+        assert_match(/t\.virtual\s+"profile_email",\s+type: :string,\s+as: "json_extract\(`profile`,\w*?'\$\.email'\)", stored: true$/i, output)
+      end
     end
   end
 end

--- a/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
+++ b/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
@@ -21,6 +21,8 @@ module FullStiClassNamesSharedTest
   end
 
   def teardown
+    Tagging.delete_all
+    Post.delete_all
     ActiveRecord::Base.store_full_sti_class = @old_store_full_sti_class
   end
 
@@ -93,6 +95,8 @@ module PolymorphicFullClassNamesSharedTest
   end
 
   def teardown
+    Namespaced::Post.delete_all
+    Tagging.delete_all
     ActiveRecord::Base.store_full_class_name = @old_store_full_class_name
   end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -49,6 +49,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
             :owners, :pets, :author_favorites, :jobs, :references, :subscribers, :subscriptions, :books,
             :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors
 
+  def teardown
+    Comment.delete_all
+    Post.delete_all
+    Member.delete_all
+  end
+
   def test_eager_with_has_one_through_join_model_with_conditions_on_the_through
     member = Member.all.merge!(includes: :favorite_club).find(members(:some_other_guy).id)
     assert_nil member.favorite_club

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1413,9 +1413,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
     comments = Post.find(1).comments.to_a
 
     Comment.where("1=0").scoping do
-      assert_equal comments, Post.find(1).comments
-      assert_equal comments, Post.preload(:comments).find(1).comments
-      assert_equal comments, Post.eager_load(:comments).find(1).comments
+      assert_equal comments, Post.find(1).comments.to_a
+      assert_equal comments, Post.preload(:comments).find(1).comments.to_a
+      assert_equal comments, Post.eager_load(:comments).find(1).comments.to_a
     end
   end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1410,6 +1410,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "has_many association ignores the scoping" do
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/14198") if ENV['tidb'].present?
     comments = Post.find(1).comments.to_a
 
     Comment.where("1=0").scoping do

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -127,6 +127,12 @@ end
 class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :categories, :posts, :categories_posts, :developers, :projects, :developers_projects,
            :parrots, :pirates, :parrots_pirates, :treasures, :price_estimates, :tags, :taggings, :computers
+  
+  def teardown
+    Country.delete_all
+    Treaty.delete_all
+    ActiveRecord::Base.connection.execute("delete from countries_treaties")
+  end
 
   def setup_data_for_habtm_case
     ActiveRecord::Base.connection.execute("delete from countries_treaties")

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -122,6 +122,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     Client.destroyed_client_ids.clear
   end
 
+  def teardown
+    Speedometer.delete_all
+    Firm.delete_all
+    Contract.delete_all
+    Minivan.delete_all
+  end
+
   def test_sti_subselect_count
     tag = Tag.first
     len = Post.tagged_with(tag.id).limit(10).size

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -127,6 +127,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     Firm.delete_all
     Contract.delete_all
     Minivan.delete_all
+    Car.delete_all
+    Engine.delete_all
   end
 
   def test_sti_subselect_count

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -49,6 +49,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create person_id: 0, post_id: 0
   end
 
+  def teardown
+    AuthorFavorite.delete_all
+  end
+
   def test_has_many_through_create_record
     assert books(:awdr).subscribers.create!(nick: "bob")
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -902,6 +902,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_association_through_a_belongs_to_association
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/14198") if ENV['tidb'].present?
     author = authors(:mary)
     post = Post.create!(author: author, title: "TITLE", body: "BODY")
     author.author_favorites.create(favorite_author_id: 1)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -28,6 +28,10 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     Account.destroyed_account_ids.clear
   end
 
+  def teardown
+    Post.delete_all
+  end
+
   def test_has_one
     firm = companies(:first_firm)
     first_account = Account.find(1)

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -36,6 +36,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
            :member_types, :sponsors, :clubs, :organizations, :categories, :categories_posts,
            :categorizations, :memberships, :essays
 
+  def teardown
+    Hotel.delete_all
+  end
+
   # Through associations can either use the has_many or has_one macros.
   #
   # has_many

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -397,6 +397,15 @@ end
 class PreloaderTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories, :author_addresses
 
+  def teardown
+    Post.delete_all
+    Comment.delete_all
+    Author.delete_all
+    Book.delete_all
+    Tag.destroy_all
+    Tagging.delete_all
+  end
+
   def test_preload_with_scope
     post = posts(:welcome)
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -398,7 +398,6 @@ class PreloaderTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories, :author_addresses
 
   def teardown
-    Post.delete_all
     Comment.delete_all
     Author.delete_all
     Book.delete_all
@@ -518,6 +517,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_predicate bob.posts_mentioning_author, :loaded?
 
     assert_equal [post, post2].sort, david.posts_mentioning_author.sort
+
     assert_equal [], david2.posts_mentioning_author
     assert_equal [], bob.posts_mentioning_author
   end
@@ -538,7 +538,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_predicate david2.comments_mentioning_author, :loaded?
     assert_predicate bob.comments_mentioning_author, :loaded?
 
-    assert_equal [comment1, comment2].sort, david.comments_mentioning_author.sort
+    assert_equal [comment1, comment2].sort, david.comments_mentioning_author.reload.sort
     assert_equal [], david2.comments_mentioning_author
     assert_equal [], bob.comments_mentioning_author
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1131,7 +1131,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 
     assert_equal 3, @pirate.birds.reload.length
   ensure
-    Bird.connection.remove_index :birds, column: :name
+    Bird.connection.remove_index :birds, column: :name rescue nil
   end
 
   # Add and remove callbacks tests for association collections.

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1120,6 +1120,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   end
 
   def test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     Bird.connection.add_index :birds, :name, unique: true
 
     3.times { |i| @pirate.birds.create(name: "unique_birds_#{i}") }

--- a/activerecord/test/cases/base_prevent_writes_test.rb
+++ b/activerecord/test/cases/base_prevent_writes_test.rb
@@ -105,6 +105,7 @@ class BasePreventWritesTest < ActiveRecord::TestCase
     def teardown
       clean_up_legacy_connection_handlers
       ActiveRecord.legacy_connection_handling = @old_value
+      Bird.delete_all
     end
 
     if !in_memory_db?

--- a/activerecord/test/cases/boolean_test.rb
+++ b/activerecord/test/cases/boolean_test.rb
@@ -4,6 +4,10 @@ require "cases/helper"
 require "models/boolean"
 
 class BooleanTest < ActiveRecord::TestCase
+  def teardown
+    Boolean.delete_all
+  end
+
   def test_boolean
     b_nil   = Boolean.create!(value: nil)
     b_false = Boolean.create!(value: false)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -25,6 +25,12 @@ require "support/stubs/strong_parameters"
 
 class CalculationsTest < ActiveRecord::TestCase
   fixtures :companies, :accounts, :authors, :author_addresses, :topics, :speedometers, :minivans, :books, :posts, :comments
+  
+  def teardown
+    Company.delete_all
+    NumericData.delete_all
+    ShipPart.delete_all
+  end
 
   def test_should_sum_field
     assert_equal 318, Account.sum(:credit_limit)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -30,6 +30,8 @@ class CalculationsTest < ActiveRecord::TestCase
     Company.delete_all
     NumericData.delete_all
     ShipPart.delete_all
+    Developer.delete_all
+    Contract.delete_all
   end
 
   def test_should_sum_field

--- a/activerecord/test/cases/date_test.rb
+++ b/activerecord/test/cases/date_test.rb
@@ -4,6 +4,10 @@ require "cases/helper"
 require "models/topic"
 
 class DateTest < ActiveRecord::TestCase
+  def teardown
+    Topic.delete_all
+  end
+
   def test_date_with_time_value
     time_value = Time.new(2016, 05, 11, 19, 0, 0)
     topic = Topic.create(last_read: time_value)

--- a/activerecord/test/cases/encryption/contexts_test.rb
+++ b/activerecord/test/cases/encryption/contexts_test.rb
@@ -7,6 +7,10 @@ require "models/post_encrypted"
 class ActiveRecord::Encryption::ContextsTest < ActiveRecord::EncryptionTestCase
   fixtures :posts
 
+  def teardown
+    EncryptedBook.delete_all
+  end
+
   setup do
     ActiveRecord::Encryption.config.support_unencrypted_data = true
 

--- a/activerecord/test/cases/encryption/contexts_test.rb
+++ b/activerecord/test/cases/encryption/contexts_test.rb
@@ -9,6 +9,8 @@ class ActiveRecord::Encryption::ContextsTest < ActiveRecord::EncryptionTestCase
 
   def teardown
     EncryptedBook.delete_all
+    EncryptedPost.delete_all
+    EncryptedAuthor.delete_all
   end
 
   setup do

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -5,6 +5,10 @@ require "models/author_encrypted"
 require "models/book"
 
 class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::EncryptionTestCase
+  def teardown
+    EncryptedAuthor2.delete_all
+  end
+
   test "can decrypt encrypted_value encrypted with a different encryption scheme" do
     ActiveRecord::Encryption.config.support_unencrypted_data = false
 

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -8,6 +8,11 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
     ActiveRecord::Encryption.config.support_unencrypted_data = true
   end
 
+  def teardown
+    EncryptedBook.delete_all
+    EncryptedBookWithDowncaseName.delete_all
+  end
+
   test "Finds records when data is unencrypted" do
     ActiveRecord::Encryption.without_encryption { UnencryptedBook.create! name: "Dune" }
     assert EncryptedBook.find_by(name: "Dune") # core

--- a/activerecord/test/cases/encryption/uniqueness_validations_test.rb
+++ b/activerecord/test/cases/encryption/uniqueness_validations_test.rb
@@ -41,5 +41,7 @@ class ActiveRecord::Encryption::UniquenessValidationsTest < ActiveRecord::Encryp
     assert_raises ActiveRecord::RecordInvalid do
       OldEncryptionBook.create! name: "DUNE"
     end
+  ensure
+    OldEncryptionBook.delete_all
   end
 end

--- a/activerecord/test/cases/encryption/uniqueness_validations_test.rb
+++ b/activerecord/test/cases/encryption/uniqueness_validations_test.rb
@@ -5,6 +5,10 @@ require "models/book_encrypted"
 require "models/author_encrypted"
 
 class ActiveRecord::Encryption::UniquenessValidationsTest < ActiveRecord::EncryptionTestCase
+  def teardown
+    EncryptedBookWithDowncaseName.delete_all
+  end
+
   test "uniqueness validations work" do
     EncryptedBookWithDowncaseName.create!(name: "dune")
     assert_raises ActiveRecord::RecordInvalid do

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -27,6 +27,9 @@ require "support/stubs/strong_parameters"
 
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :author_addresses, :customers, :categories, :categorizations, :cars
+  def teardown
+    Subscriber.delete_all
+  end
 
   def test_find_by_id_with_hash
     assert_nothing_raised do

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -127,6 +127,7 @@ class FixturesTest < ActiveRecord::TestCase
     end
 
     def test_bulk_insert_with_a_multi_statement_query_in_a_nested_transaction
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
       fixtures = {
         "traffic_lights" => [
           { "location" => "US", "state" => ["NY"], "long_state" => ["a"] },
@@ -146,6 +147,7 @@ class FixturesTest < ActiveRecord::TestCase
 
   if current_adapter?(:Mysql2Adapter)
     def test_bulk_insert_with_multi_statements_enabled
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(
           orig_connection.merge(flags: %w[MULTI_STATEMENTS])
@@ -719,19 +721,21 @@ class FixturesWithoutInstanceInstantiationTest < ActiveRecord::TestCase
   end
 end
 
-class TransactionalFixturesTest < ActiveRecord::TestCase
-  self.use_instantiated_fixtures = true
-  self.use_transactional_tests = true
+if ENV['tidb'].blank?
+  class TransactionalFixturesTest < ActiveRecord::TestCase
+    self.use_instantiated_fixtures = true
+    self.use_transactional_tests = true
 
-  fixtures :topics
+    fixtures :topics
 
-  def test_destroy
-    assert_not_nil @first
-    @first.destroy
-  end
+    def test_destroy
+      assert_not_nil @first
+      @first.destroy
+    end
 
-  def test_destroy_just_kidding
-    assert_not_nil @first
+    def test_destroy_just_kidding
+      assert_not_nil @first
+    end
   end
 end
 
@@ -964,96 +968,100 @@ class CustomConnectionFixturesTest < ActiveRecord::TestCase
   end
 end
 
-class TransactionalFixturesOnCustomConnectionTest < ActiveRecord::TestCase
-  set_fixture_class courses: Course
-  fixtures :courses
-  self.use_transactional_tests = true
+if ENV['tidb'].blank?
+  class TransactionalFixturesOnCustomConnectionTest < ActiveRecord::TestCase
+    set_fixture_class courses: Course
+    fixtures :courses
+    self.use_transactional_tests = true
 
-  def test_leaky_destroy
-    assert_nothing_raised { courses(:ruby) }
-    courses(:ruby).destroy
-  end
+    def test_leaky_destroy
+      assert_nothing_raised { courses(:ruby) }
+      courses(:ruby).destroy
+    end
 
-  def test_it_twice_in_whatever_order_to_check_for_fixture_leakage
-    test_leaky_destroy
+    def test_it_twice_in_whatever_order_to_check_for_fixture_leakage
+      test_leaky_destroy
+    end
   end
 end
 
-class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
-  self.use_transactional_tests = true
-  self.use_instantiated_fixtures = false
+if ENV['tidb'].blank?
+  class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
+    self.use_transactional_tests = true
+    self.use_instantiated_fixtures = false
 
-  def test_transaction_created_on_connection_notification
-    connection = Class.new do
-      attr_accessor :pool
+    def test_transaction_created_on_connection_notification
+      connection = Class.new do
+        attr_accessor :pool
 
-      def transaction_open?; end
-      def begin_transaction(*args); end
-      def rollback_transaction(*args); end
-    end.new
+        def transaction_open?; end
+        def begin_transaction(*args); end
+        def rollback_transaction(*args); end
+      end.new
 
-    connection.pool = Class.new do
-      def lock_thread=(lock_thread); end
-    end.new
+      connection.pool = Class.new do
+        def lock_thread=(lock_thread); end
+      end.new
 
-    assert_called_with(connection, :begin_transaction, [joinable: false, _lazy: false]) do
+      assert_called_with(connection, :begin_transaction, [joinable: false, _lazy: false]) do
+        fire_connection_notification(connection)
+      end
+    end
+
+    def test_notification_established_transactions_are_rolled_back
+      connection = Class.new do
+        attr_accessor :rollback_transaction_called
+        attr_accessor :pool
+
+        def transaction_open?; true; end
+        def begin_transaction(*args); end
+        def rollback_transaction(*args)
+          @rollback_transaction_called = true
+        end
+      end.new
+
+      connection.pool = Class.new do
+        def lock_thread=(lock_thread); end
+      end.new
+
       fire_connection_notification(connection)
+      teardown_fixtures
+
+      assert(connection.rollback_transaction_called, "Expected <mock connection>#rollback_transaction to be called but was not")
     end
-  end
 
-  def test_notification_established_transactions_are_rolled_back
-    connection = Class.new do
-      attr_accessor :rollback_transaction_called
-      attr_accessor :pool
+    def test_transaction_created_on_connection_notification_for_shard
+      connection = Class.new do
+        attr_accessor :pool
 
-      def transaction_open?; true; end
-      def begin_transaction(*args); end
-      def rollback_transaction(*args)
-        @rollback_transaction_called = true
-      end
-    end.new
+        def transaction_open?; end
+        def begin_transaction(*args); end
+        def rollback_transaction(*args); end
+      end.new
 
-    connection.pool = Class.new do
-      def lock_thread=(lock_thread); end
-    end.new
+      connection.pool = Class.new do
+        def lock_thread=(lock_thread); end
+      end.new
 
-    fire_connection_notification(connection)
-    teardown_fixtures
-
-    assert(connection.rollback_transaction_called, "Expected <mock connection>#rollback_transaction to be called but was not")
-  end
-
-  def test_transaction_created_on_connection_notification_for_shard
-    connection = Class.new do
-      attr_accessor :pool
-
-      def transaction_open?; end
-      def begin_transaction(*args); end
-      def rollback_transaction(*args); end
-    end.new
-
-    connection.pool = Class.new do
-      def lock_thread=(lock_thread); end
-    end.new
-
-    assert_called_with(connection, :begin_transaction, [joinable: false, _lazy: false]) do
-      fire_connection_notification(connection, shard: :shard_two)
-    end
-  end
-
-  private
-    def fire_connection_notification(connection, shard: ActiveRecord::Base.default_shard)
-      assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book", { shard: shard }], returns: connection) do
-        message_bus = ActiveSupport::Notifications.instrumenter
-        payload = {
-          spec_name: "book",
-          shard: shard,
-          config: nil,
-        }
-
-        message_bus.instrument("!connection.active_record", payload) { }
+      assert_called_with(connection, :begin_transaction, [joinable: false, _lazy: false]) do
+        fire_connection_notification(connection, shard: :shard_two)
       end
     end
+
+    private
+      def fire_connection_notification(connection, shard: ActiveRecord::Base.default_shard)
+        assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book", { shard: shard }], returns: connection) do
+          message_bus = ActiveSupport::Notifications.instrumenter
+          payload = {
+            spec_name: "book",
+            shard: shard,
+            config: nil,
+          }
+
+          message_bus.instrument("!connection.active_record", payload) { }
+        end
+      end
+  end
 end
 
 class InvalidTableNameFixturesTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -244,6 +244,7 @@ module ActiveRecord
     end
 
     def test_exception_on_removing_index_without_column_option
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       index_definition = ["horses", [:name, :color]]
       migration1 = RemoveIndexMigration1.new
       migration1.migrate(:up)
@@ -471,6 +472,7 @@ module ActiveRecord
     end
 
     def test_migrations_can_handle_foreign_keys_to_specific_tables
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26111") if ENV['tidb'].present?
       migration = RevertCustomForeignKeyTable.new
       InvertibleMigration.migrate(:up)
       migration.migrate(:up)
@@ -493,6 +495,7 @@ module ActiveRecord
     end
 
     def test_migrate_revert_add_index_without_name_on_expression
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       InvertibleMigration.new.migrate(:up)
       RevertNonNamedExpressionIndexMigration.new.migrate(:up)
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -26,6 +26,7 @@ module ActiveRecord
       end
 
       def test_add_column_with_primary_key_attribute
+        skip("TiDB issue: https://docs.pingcap.com/tidb/stable/constraints#primary-key") if ENV['tidb'].present?
         testing_table_with_only_foo_attribute do
           connection.add_column :testings, :id, :primary_key
           assert_equal connection.columns(:testings).size, 2

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -94,6 +94,7 @@ module ActiveRecord
       end
 
       def test_rename_column_with_an_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_column "test_models", :hat_name, :string
         add_index :test_models, :hat_name
 
@@ -104,6 +105,7 @@ module ActiveRecord
       end
 
       def test_rename_column_with_multi_column_index
+        skip('TiDB issue: https://github.com/pingcap/tidb/issues/3364') if ENV['tidb'].present?
         add_column "test_models", :hat_size, :integer
         add_column "test_models", :hat_style, :string, limit: 100
         add_index "test_models", ["hat_style", "hat_size"], unique: true
@@ -134,6 +136,7 @@ module ActiveRecord
       end
 
       def test_remove_column_with_multi_column_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         # MariaDB starting with 10.2.8
         # Dropping a column that is part of a multi-column UNIQUE constraint is not permitted.
         skip if current_adapter?(:Mysql2Adapter) && connection.mariadb? && connection.database_version >= "10.2.8"
@@ -323,6 +326,7 @@ module ActiveRecord
       end
 
       def test_remove_columns_single_statement
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
         connection.create_table "my_table" do |t|
           t.integer "col_one"
           t.integer "col_two"

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -305,6 +305,7 @@ module ActiveRecord
       end
 
       def test_column_with_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table "my_table", force: true do |t|
           t.string :item_number, index: true
         end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -29,6 +29,7 @@ module ActiveRecord
       end
 
       def test_migration_doesnt_remove_named_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, name: "custom_index_name"
 
         migration = Class.new(ActiveRecord::Migration[4.2]) {
@@ -44,6 +45,7 @@ module ActiveRecord
       end
 
       def test_migration_does_remove_unnamed_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :bar
 
         migration = Class.new(ActiveRecord::Migration[4.2]) {
@@ -290,6 +292,7 @@ module ActiveRecord
       end
 
       def test_change_table_with_polymorphic_reference_uses_all_column_names_in_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         migration = Class.new(ActiveRecord::Migration[6.0]) {
           def migrate(x)
             change_table :testings do |t|
@@ -306,6 +309,7 @@ module ActiveRecord
       end
 
       def test_create_join_table_with_polymorphic_reference_uses_all_column_names_in_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         migration = Class.new(ActiveRecord::Migration[6.0]) {
           def migrate(x)
             create_join_table :more, :testings do |t|
@@ -324,6 +328,7 @@ module ActiveRecord
       end
 
       def test_polymorphic_add_reference_uses_all_column_names_in_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         migration = Class.new(ActiveRecord::Migration[6.0]) {
           def migrate(x)
             add_reference :testings, :widget, polymorphic: true, index: true
@@ -719,6 +724,7 @@ module LegacyPrimaryKeyTestCases
     @migration.migrate(:down) if @migration
     ActiveRecord::Migration.verbose = @verbose_was
     ActiveRecord::SchemaMigration.delete_all rescue nil
+    ActiveRecord::Base.connection.drop_table :legacy_primary_keys, if_exists: true
     LegacyPrimaryKey.reset_column_information
   end
 
@@ -784,6 +790,7 @@ module LegacyPrimaryKeyTestCases
   end
 
   def test_legacy_primary_key_in_change_table_should_be_integer
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/10190") if ENV['tidb'].present?
     @migration = Class.new(migration_class) {
       def change
         create_table :legacy_primary_keys, id: false do |t|
@@ -801,6 +808,7 @@ module LegacyPrimaryKeyTestCases
   end
 
   def test_add_column_with_legacy_primary_key_should_be_integer
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/10190") if ENV['tidb'].present?
     @migration = Class.new(migration_class) {
       def change
         create_table :legacy_primary_keys, id: false do |t|

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -73,6 +73,7 @@ module ActiveRecord
       end
 
       def test_create_join_table_with_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_join_table :artists, :musics do |t|
           t.index [:artist_id, :music_id]
         end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -82,6 +82,7 @@ module ActiveRecord
       end
 
       def test_add_index_which_already_exists_does_not_raise_error_with_option
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index(table_name, "foo")
 
         assert_nothing_raised do
@@ -104,6 +105,7 @@ module ActiveRecord
       end
 
       def test_remove_index_which_does_not_exist_doesnt_raise_with_option
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index(table_name, "foo")
 
         connection.remove_index(table_name, "foo")
@@ -118,6 +120,7 @@ module ActiveRecord
       end
 
       def test_remove_index_with_name_which_does_not_exist_doesnt_raise_with_option
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index(table_name, [:foo], name: "foo")
 
         assert connection.index_exists?(table_name, :foo, name: "foo")
@@ -136,6 +139,7 @@ module ActiveRecord
       end
 
       def test_index_symbol_names
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index table_name, :foo, name: :symbol_index_name
         assert connection.index_exists?(table_name, :foo, name: :symbol_index_name)
 
@@ -144,6 +148,7 @@ module ActiveRecord
       end
 
       def test_index_exists
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo
 
         assert connection.index_exists?(:testings, :foo)
@@ -151,30 +156,35 @@ module ActiveRecord
       end
 
       def test_index_exists_on_multiple_columns
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, [:foo, :bar]
 
         assert connection.index_exists?(:testings, [:foo, :bar])
       end
 
       def test_index_exists_with_custom_name_checks_columns
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, [:foo, :bar], name: "my_index"
         assert connection.index_exists?(:testings, [:foo, :bar], name: "my_index")
         assert_not connection.index_exists?(:testings, [:foo], name: "my_index")
       end
 
       def test_valid_index_options
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         assert_raise ArgumentError do
           connection.add_index :testings, :foo, unqiue: true
         end
       end
 
       def test_unique_index_exists
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, unique: true
 
         assert connection.index_exists?(:testings, :foo, unique: true)
       end
 
       def test_named_index_exists
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, name: "custom_index_name"
 
         assert connection.index_exists?(:testings, :foo)
@@ -183,6 +193,7 @@ module ActiveRecord
       end
 
       def test_remove_named_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, name: "index_testings_on_custom_index_name"
 
         assert connection.index_exists?(:testings, :foo)
@@ -194,12 +205,14 @@ module ActiveRecord
       end
 
       def test_add_index_attribute_length_limit
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, [:foo, :bar], length: { foo: 10, bar: nil }
 
         assert connection.index_exists?(:testings, [:foo, :bar])
       end
 
       def test_add_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index("testings", "last_name")
         connection.remove_index("testings", "last_name")
 

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -157,6 +157,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testing_parents do |t|
             t.references :testing, foreign_key: true
           end
+          @connection.remove_reference :testing_parents, :testing, foreign_key: true
           skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testing_parents").first
           assert_equal "testing_parents", fk.from_table

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -20,7 +20,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").first
           assert_equal "testings", fk.from_table
           assert_equal "testing_parents", fk.to_table
@@ -49,7 +49,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
           assert_equal "other_id", fk.primary_key
         end
@@ -58,7 +58,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :parent, foreign_key: { to_table: :testing_parents }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fks = @connection.foreign_keys("testings")
           assert_equal([["testings", "testing_parents", "parent_id"]],
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
@@ -93,7 +92,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testings do |t|
             t.references :testing_parent, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").first
           assert_equal "testings", fk.from_table
           assert_equal "testing_parents", fk.to_table
@@ -116,7 +115,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testings do |t|
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
           assert_equal "other_id", fk.primary_key
         end
@@ -134,7 +133,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, index: true, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_reference :testings, :testing_parent, foreign_key: true
           end
@@ -144,7 +143,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, index: true, foreign_key: true
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_column :testings, :testing_parent_id
           end
@@ -157,8 +156,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testing_parents do |t|
             t.references :testing, foreign_key: true
           end
-          @connection.remove_reference :testing_parents, :testing, foreign_key: true
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testing_parents").first
           assert_equal "testing_parents", fk.from_table
           assert_equal "testing", fk.to_table
@@ -185,7 +182,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           ActiveRecord::Base.table_name_prefix = "p_"
           migration = CreateDogsMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_equal 1, @connection.foreign_keys("p_dogs").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
@@ -196,7 +192,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           ActiveRecord::Base.table_name_suffix = "_s"
           migration = CreateDogsMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_equal 1, @connection.foreign_keys("dogs_s").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
@@ -209,7 +204,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :parent2, foreign_key: { to_table: :testing_parents }
             t.references :self_join, foreign_key: { to_table: :testings }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           fks = @connection.foreign_keys("testings").sort_by(&:column)
 
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }
@@ -223,11 +218,11 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :parent1, foreign_key: { to_table: :testing_parents }
             t.references :parent2, foreign_key: { to_table: :testing_parents }
           end
-          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
+
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_reference :testings, :parent1, foreign_key: { to_table: :testing_parents }
           end
-          
+
           fks = @connection.foreign_keys("testings").sort_by(&:column)
 
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -20,7 +20,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: true
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testings").first
           assert_equal "testings", fk.from_table
           assert_equal "testing_parents", fk.to_table
@@ -49,7 +49,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
           assert_equal "other_id", fk.primary_key
         end
@@ -58,6 +58,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :parent, foreign_key: { to_table: :testing_parents }
           end
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fks = @connection.foreign_keys("testings")
           assert_equal([["testings", "testing_parents", "parent_id"]],
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
@@ -92,7 +93,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testings do |t|
             t.references :testing_parent, foreign_key: true
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testings").first
           assert_equal "testings", fk.from_table
           assert_equal "testing_parents", fk.to_table
@@ -115,7 +116,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testings do |t|
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
           assert_equal "other_id", fk.primary_key
         end
@@ -133,7 +134,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, index: true, foreign_key: true
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_reference :testings, :testing_parent, foreign_key: true
           end
@@ -143,7 +144,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.create_table :testings do |t|
             t.references :testing_parent, index: true, foreign_key: true
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_column :testings, :testing_parent_id
           end
@@ -156,7 +157,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.change_table :testing_parents do |t|
             t.references :testing, foreign_key: true
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fk = @connection.foreign_keys("testing_parents").first
           assert_equal "testing_parents", fk.from_table
           assert_equal "testing", fk.to_table
@@ -183,6 +184,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           ActiveRecord::Base.table_name_prefix = "p_"
           migration = CreateDogsMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_equal 1, @connection.foreign_keys("p_dogs").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
@@ -193,6 +195,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           ActiveRecord::Base.table_name_suffix = "_s"
           migration = CreateDogsMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_equal 1, @connection.foreign_keys("dogs_s").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
@@ -205,7 +208,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :parent2, foreign_key: { to_table: :testing_parents }
             t.references :self_join, foreign_key: { to_table: :testings }
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           fks = @connection.foreign_keys("testings").sort_by(&:column)
 
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }
@@ -219,11 +222,11 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :parent1, foreign_key: { to_table: :testing_parents }
             t.references :parent2, foreign_key: { to_table: :testing_parents }
           end
-
+          skip "TiDB Issue: https://docs.pingcap.com/tidb/stable/constraints#notes"
           assert_difference "@connection.foreign_keys('testings').size", -1 do
             @connection.remove_reference :testings, :parent1, foreign_key: { to_table: :testing_parents }
           end
-
+          
           fks = @connection.foreign_keys("testings").sort_by(&:column)
 
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -18,6 +18,7 @@ module ActiveRecord
       end
 
       def test_creates_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name do |t|
           t.references :foo, index: true
         end
@@ -26,6 +27,7 @@ module ActiveRecord
       end
 
       def test_creates_index_by_default_even_if_index_option_is_not_passed
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name do |t|
           t.references :foo
         end
@@ -42,6 +44,7 @@ module ActiveRecord
       end
 
       def test_creates_index_with_options
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name do |t|
           t.references :foo, index: { name: :index_testings_on_yo_momma }
           t.references :bar, index: { unique: true }
@@ -53,6 +56,7 @@ module ActiveRecord
 
       unless current_adapter? :OracleAdapter
         def test_creates_polymorphic_index
+          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name do |t|
             t.references :foo, polymorphic: true, index: true
           end
@@ -61,6 +65,7 @@ module ActiveRecord
         end
 
         def test_creates_polymorphic_index_with_custom_name
+          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name do |t|
             t.references :foo, polymorphic: true, index: { name: :testings_foo_index }
           end
@@ -70,6 +75,7 @@ module ActiveRecord
       end
 
       def test_creates_index_for_existing_table
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name
         connection.change_table table_name do |t|
           t.references :foo, index: true
@@ -79,6 +85,7 @@ module ActiveRecord
       end
 
       def test_creates_index_for_existing_table_even_if_index_option_is_not_passed
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name
         connection.change_table table_name do |t|
           t.references :foo
@@ -98,6 +105,7 @@ module ActiveRecord
 
       unless current_adapter? :OracleAdapter
         def test_creates_polymorphic_index_for_existing_table
+          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name
           connection.change_table table_name do |t|
             t.references :foo, polymorphic: true, index: true
@@ -107,6 +115,7 @@ module ActiveRecord
         end
 
         def test_creates_polymorphic_index_for_existing_table_with_custom_name
+          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name
           connection.change_table table_name do |t|
             t.references :foo, polymorphic: true, index: { name: :testings_foo_index }

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -45,11 +45,13 @@ module ActiveRecord
       end
 
       def test_create_reference_id_index_even_if_index_option_is_not_passed
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :user
         assert index_exists?(table_name, :user_id)
       end
 
       def test_creates_polymorphic_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :taggable, polymorphic: true, index: true
         assert index_exists?(table_name, [:taggable_type, :taggable_id])
       end
@@ -75,11 +77,13 @@ module ActiveRecord
       end
 
       def test_creates_named_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id" }
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id")
       end
 
       def test_creates_named_unique_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id", unique: true }
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id", unique: true)
       end
@@ -100,6 +104,7 @@ module ActiveRecord
       end
 
       def test_does_not_delete_reference_type_column
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/3364") if ENV['tidb'].present?
         with_polymorphic_column do
           remove_reference table_name, :supplier
 
@@ -109,6 +114,7 @@ module ActiveRecord
       end
 
       def test_deletes_reference_type_column
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/3364") if ENV['tidb'].present?
         with_polymorphic_column do
           remove_reference table_name, :supplier, polymorphic: true
           assert_not column_exists?(table_name, :supplier_type, :string)
@@ -116,6 +122,7 @@ module ActiveRecord
       end
 
       def test_deletes_polymorphic_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         with_polymorphic_column do
           remove_reference table_name, :supplier, polymorphic: true
           assert_not index_exists?(table_name, [:supplier_id, :supplier_type])

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -50,6 +50,7 @@ module ActiveRecord
       end
 
       def test_rename_table_with_an_index
+        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_index :test_models, :url
 
         rename_table :test_models, :octopi

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -851,6 +851,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   unless mysql_enforcing_gtid_consistency?
     def test_create_table_with_query
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/4754") if ENV['tidb'].present?
       Person.connection.create_table :table_from_query_testings, as: "SELECT id FROM people WHERE id = 1"
 
       columns = Person.connection.columns(:table_from_query_testings)
@@ -862,6 +863,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
 
     def test_create_table_with_query_from_relation
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/4754") if ENV['tidb'].present?
       Person.connection.create_table :table_from_query_testings, as: Person.select(:id).where(id: 1)
 
       columns = Person.connection.columns(:table_from_query_testings)
@@ -1134,6 +1136,7 @@ end
 
 class ExplicitlyNamedIndexMigrationTest < ActiveRecord::TestCase
   def test_drop_index_by_name
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     connection = Person.connection
     connection.create_table :values, force: true do |t|
       t.integer :value
@@ -1162,6 +1165,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_adding_multiple_columns
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 1,
@@ -1187,6 +1191,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_rename_columns
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :qualification
       end
@@ -1204,6 +1209,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_removing_columns
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :qualification, :experience
       end
@@ -1222,6 +1228,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_adding_timestamps
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :title
       end
@@ -1240,6 +1247,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_removing_timestamps
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.timestamps
       end
@@ -1258,6 +1266,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_adding_indexes
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :username
         t.string :name
@@ -1290,6 +1299,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_removing_index
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :name
         t.index :name
@@ -1319,6 +1329,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_changing_columns
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :name
         t.date :birthdate
@@ -1389,6 +1400,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     end
 
     def test_changing_index
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/5166") if ENV['tidb'].present?
       with_bulk_change_table do |t|
         t.string :username
         t.index :username, name: :username_index

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -210,6 +210,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_remove_column_with_if_not_exists_not_set
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26137") if ENV['tidb'].present?
     migration_a = Class.new(ActiveRecord::Migration::Current) {
       def version; 100 end
       def migrate(x)
@@ -958,6 +959,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   if ActiveRecord::Base.connection.supports_advisory_locks?
     def test_migrator_generates_valid_lock_id
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
       migration = Class.new(ActiveRecord::Migration::Current).new
       migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
 
@@ -970,6 +972,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
 
     def test_generate_migrator_advisory_lock_id
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
       # It is important we are consistent with how we generate this so that
       # exclusive locking works across migrator versions
       migration = Class.new(ActiveRecord::Migration::Current).new
@@ -986,6 +989,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
 
     def test_migrator_one_up_with_unavailable_lock
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
       assert_no_column Person, :last_name
 
       migration = Class.new(ActiveRecord::Migration::Current) {
@@ -1007,6 +1011,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
 
     def test_migrator_one_up_with_unavailable_lock_using_run
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
       assert_no_column Person, :last_name
 
       migration = Class.new(ActiveRecord::Migration::Current) {
@@ -1064,6 +1069,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
 
     def test_with_advisory_lock_raises_the_right_error_when_it_fails_to_release_lock
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/14994") if ENV['tidb'].present?
       migration = Class.new(ActiveRecord::Migration::Current).new
       migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
@@ -1120,6 +1126,7 @@ end
 
 class ReservedWordsMigrationTest < ActiveRecord::TestCase
   def test_drop_index_from_table_named_values
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     connection = Person.connection
     connection.create_table :values, force: true do |t|
       t.integer :value

--- a/activerecord/test/cases/nested_attributes_with_callbacks_test.rb
+++ b/activerecord/test/cases/nested_attributes_with_callbacks_test.rb
@@ -29,6 +29,10 @@ class NestedAttributesWithCallbacksTest < ActiveRecord::TestCase
     @birds = @pirate.birds.to_a
   end
 
+  def teardown
+    Bird.delete_all
+  end
+
   def bird_to_update
     @birds[0]
   end

--- a/activerecord/test/cases/numeric_data_test.rb
+++ b/activerecord/test/cases/numeric_data_test.rb
@@ -4,6 +4,10 @@ require "cases/helper"
 require "models/numeric_data"
 
 class NumericDataTest < ActiveRecord::TestCase
+  def teardown
+    NumericData.delete_all
+  end
+  
   def test_big_decimal_conditions
     m = NumericData.new(
       bank_balance: 1586.43,

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -186,12 +186,15 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 
   def test_primary_key_update_with_custom_key_name
+
     dashboard = Dashboard.create!(dashboard_id: "1")
     dashboard.id = "2"
     dashboard.save!
 
     dashboard = Dashboard.first
     assert_equal "2", dashboard.id
+  ensure
+    dashboard.destroy
   end
 
   def test_create_without_primary_key_no_extra_query
@@ -202,6 +205,8 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     end
     klass.create! # warmup schema cache
     assert_queries(3, ignore_none: true) { klass.create! }
+  ensure
+    Dashboard.delete_all
   end
 
   def test_assign_id_raises_error_if_primary_key_doesnt_exist
@@ -210,6 +215,8 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     end
     dashboard = klass.new
     assert_raises(ActiveModel::MissingAttributeError) { dashboard.id = "1" }
+  ensure
+    Dashboard.delete_all
   end
 
   if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -908,15 +908,17 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
     end
   end
 
-  test "threads use the same connection" do
-    @connection_1 = ActiveRecord::Base.connection.object_id
+  if ENV['tidb'].blank?
+    test "threads use the same connection" do
+      @connection_1 = ActiveRecord::Base.connection.object_id
 
-    thread_a = Thread.new do
-      @connection_2 = ActiveRecord::Base.connection.object_id
+      thread_a = Thread.new do
+        @connection_2 = ActiveRecord::Base.connection.object_id
+      end
+
+      thread_a.join
+
+      assert_equal @connection_1, @connection_2
     end
-
-    thread_a.join
-
-    assert_equal @connection_1, @connection_2
   end
 end

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -37,6 +37,12 @@ class ReflectionTest < ActiveRecord::TestCase
     @first = Topic.find(1)
   end
 
+  def teardown
+    Hotel.delete_all 
+    Department.delete_all
+    Chef.delete_all
+  end
+
   def test_human_name
     assert_equal "Price estimate", PriceEstimate.model_name.human
     assert_equal "Subscriber", Subscriber.model_name.human

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -11,6 +11,14 @@ module ActiveRecord
   class RelationTest < ActiveRecord::TestCase
     fixtures :posts, :comments, :authors, :author_addresses, :ratings, :categorizations
 
+    def teardown
+      Post.delete_all
+      Comment.delete_all
+      Author.delete_all
+      Rating.delete_all
+      Categorization.delete_all
+    end
+
     def test_construction
       relation = Relation.new(FakeKlass, table: :b)
       assert_equal FakeKlass, relation.klass

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -30,6 +30,11 @@ require "models/subscriber"
 class RelationTest < ActiveRecord::TestCase
   fixtures :authors, :author_addresses, :topics, :entrants, :developers, :people, :companies, :developers_projects, :accounts, :categories, :categorizations, :categories_posts, :posts, :comments, :tags, :taggings, :cars, :minivans
 
+  def teardown
+    Bird.delete_all
+    Subscriber.delete_all
+  end
+
   def test_do_not_double_quote_string_id
     van = Minivan.last
     assert van
@@ -1386,6 +1391,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_first_or_create_bang_with_valid_block
+
     canary = Bird.create!(color: "yellow", name: "canary")
     parrot = Bird.where(color: "green").first_or_create! do |bird|
       bird.name = "parrot"
@@ -1509,6 +1515,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_create_or_find_by_within_transaction
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
     assert_nil Subscriber.find_by(nick: "bob")
 
     subscriber = Subscriber.create!(nick: "bob")
@@ -1541,6 +1548,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_create_or_find_by_with_bang_within_transaction
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
     assert_nil Subscriber.find_by(nick: "bob")
 
     subscriber = Subscriber.create!(nick: "bob")

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -33,6 +33,7 @@ class RelationTest < ActiveRecord::TestCase
   def teardown
     Bird.delete_all
     Subscriber.delete_all
+    Author.delete_all
   end
 
   def test_do_not_double_quote_string_id

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -34,6 +34,7 @@ class RelationTest < ActiveRecord::TestCase
     Bird.delete_all
     Subscriber.delete_all
     Author.delete_all
+    Possession.delete_all
   end
 
   def test_do_not_double_quote_string_id

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -35,6 +35,7 @@ class RelationTest < ActiveRecord::TestCase
     Subscriber.delete_all
     Author.delete_all
     Possession.delete_all
+    Company.connection.execute("DELETE FROM companies")
   end
 
   def test_do_not_double_quote_string_id

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -164,6 +164,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_columns_in_right_order
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_index/).first.strip
     if current_adapter?(:Mysql2Adapter)
       if ActiveRecord::Base.connection.supports_index_sort_order?
@@ -179,6 +180,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_partial_indices
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_partial_index/).first.strip
     if ActiveRecord::Base.connection.supports_partial_index?
       assert_equal 't.index ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)"', index_definition
@@ -188,6 +190,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_sort_order
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*_name_and_rating/).first.strip
     if ActiveRecord::Base.connection.supports_index_sort_order?
       assert_equal 't.index ["name", "rating"], name: "index_companies_on_name_and_rating", order: :desc', index_definition
@@ -197,6 +200,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_length
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*_name_and_description/).first.strip
     if current_adapter?(:Mysql2Adapter)
       assert_equal 't.index ["name", "description"], name: "index_companies_on_name_and_description", length: 10', index_definition
@@ -297,6 +301,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
 
     def test_schema_dumps_index_type
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       output = dump_table_schema "key_tests"
       assert_match %r{t\.index \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext$}, output
       assert_match %r{t\.index \["pizza"\], name: "index_key_tests_on_pizza"$}, output

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -17,6 +17,7 @@ module ActiveRecord
       Book.delete_all
       Liquid.delete_all
       Molecule.delete_all
+      @connection.execute("DELETE FROM birds")
     end
 
     def test_statement_cache

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -13,6 +13,12 @@ module ActiveRecord
       @connection = ActiveRecord::Base.connection
     end
 
+    def teardown
+      Book.delete_all
+      Liquid.delete_all
+      Molecule.delete_all
+    end
+
     def test_statement_cache
       Book.create(name: "my book")
       Book.create(name: "my other book")

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
     self.fixture_path = FIXTURES_ROOT
     self.use_instantiated_fixtures = false
-    self.use_transactional_tests = true
+    self.use_transactional_tests = false
 
     def create_fixtures(*fixture_set_names, &block)
       ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
     self.fixture_path = FIXTURES_ROOT
     self.use_instantiated_fixtures = false
-    self.use_transactional_tests = false
+    self.use_transactional_tests = ENV['tidb'].present? ? false : true
 
     def create_fixtures(*fixture_set_names, &block)
       ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -488,6 +488,7 @@ class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
   end
 
   def test_index_is_created_for_both_timestamps
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
       t.timestamps null: true, index: true
     end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -496,6 +496,6 @@ class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
     indexes = ActiveRecord::Base.connection.indexes("foos")
     assert_equal ["created_at", "updated_at"], indexes.flat_map(&:columns).sort
   ensure
-    ActiveRecord::Base.connection.drop_table(:foos)
+    ActiveRecord::Base.connection.drop_table(:foos) rescue nil
   end
 end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -239,6 +239,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   end
 
   def test_only_call_after_commit_on_top_level_transactions
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
     @first.after_commit_block { |r| r.history << :after_commit }
     assert_empty @first.history
 

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -15,7 +15,7 @@ unless ActiveRecord::Base.connection.supports_transaction_isolation? && !current
       end
     end
   end
-else
+else 
   class TransactionIsolationTest < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
@@ -81,9 +81,11 @@ else
     # We are only testing that there are no errors because it's too hard to
     # test serializable. Databases behave differently to enforce the serializability
     # constraint.
-    test "serializable" do
-      Tag.transaction(isolation: :serializable) do
-        Tag.create
+    if ActiveRecord::Base.connection.transaction_isolation_levels.include?(:serializable)
+      test "serializable" do
+        Tag.transaction(isolation: :serializable) do
+          Tag.create
+        end
       end
     end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -479,7 +479,7 @@ class TransactionTest < ActiveRecord::TestCase
 
     assert_not_predicate topic_one, :persisted?
     assert_not_predicate topic_two, :persisted?
-  end
+  end if Topic.connection.supports_savepoints?
 
   def test_nested_transaction_without_new_transaction_applies_parent_state_on_rollback
     topic_one = Topic.new(title: "A new topic")
@@ -500,7 +500,7 @@ class TransactionTest < ActiveRecord::TestCase
 
     assert_not_predicate topic_one, :persisted?
     assert_not_predicate topic_two, :persisted?
-  end
+  end if Topic.connection.supports_savepoints?
 
   def test_double_nested_transaction_applies_parent_state_on_rollback
     topic_one = Topic.new(title: "A new topic")
@@ -689,7 +689,7 @@ class TransactionTest < ActiveRecord::TestCase
         Topic.connection.release_savepoint("another")
       end
     end
-  end
+  end if Topic.connection.supports_savepoints?
 
   def test_savepoints_name
     Topic.transaction do
@@ -709,7 +709,7 @@ class TransactionTest < ActiveRecord::TestCase
         assert_equal "active_record_1", Topic.connection.current_transaction.savepoint_name
       end
     end
-  end
+  end if Topic.connection.supports_savepoints?
 
   def test_rollback_when_commit_raises
     assert_called(Topic.connection, :begin_db_transaction) do
@@ -1114,7 +1114,7 @@ class TransactionTest < ActiveRecord::TestCase
         Topic.transaction(requires_new: true) { }
       end
     end
-  end
+  end if Topic.connection.supports_savepoints?
 
   def test_raising_does_not_materialize_transaction
     assert_no_queries do
@@ -1184,7 +1184,7 @@ class TransactionsWithTransactionalFixturesTest < ActiveRecord::TestCase
     rescue
       assert_not_predicate @first.reload, :approved?
     end
-  end
+  end if Topic.connection.supports_savepoints?
 
   def test_no_automatic_savepoint_for_inner_transaction
     @first = Topic.find(1)

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -73,6 +73,10 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
   repair_validations(Topic, Reply)
 
+  def teardown
+    Topic.delete_all
+  end
+
   def test_validate_uniqueness
     Topic.validates_uniqueness_of(:title)
 
@@ -336,6 +340,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   end
 
   def test_validate_uniqueness_by_default_database_collation
+    skip("TiDB issue: https://github.com/pingcap/tidb/issues/7519") if ENV['tidb'].present?
     Topic.validates_uniqueness_of(:author_email_address)
 
     topic1 = Topic.new(author_email_address: "david@loudthinking.com")

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -156,7 +156,7 @@ if ActiveRecord::Base.connection.supports_views?
   end
 
   # sqlite dose not support CREATE, INSERT, and DELETE for VIEW
-  if current_adapter?(:Mysql2Adapter, :SQLServerAdapter, :PostgreSQLAdapter)
+  if current_adapter?(:Mysql2Adapter, :SQLServerAdapter, :PostgreSQLAdapter) && ENV['tidb'].blank?
 
     class UpdateableViewTest < ActiveRecord::TestCase
       self.use_transactional_tests = false

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -54,6 +54,9 @@ connections:
           tidb_enable_noop_functions: ON
           tidb_skip_isolation_level_check: 1
 <% end %>
+<% if ENV['MYSQL_SOCK'] %>
+      socket: "<%= ENV['MYSQL_SOCK'] %>"
+<% end %>
     arunit2:
       username: <%= ENV["MYSQL_USER"] || 'rails' %>
       port: <%= ENV["MYSQL_PORT"] || 3306 %>
@@ -71,6 +74,12 @@ connections:
       variables:
           tidb_enable_noop_functions: ON
           tidb_skip_isolation_level_check: 1
+<<<<<<< HEAD
+=======
+<% end %>
+<% if ENV['MYSQL_SOCK'] %>
+      socket: "<%= ENV['MYSQL_SOCK'] %>"
+>>>>>>> 176d31aded (fix config.yml)
 <% end %>
 
   oracle:

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -49,6 +49,9 @@ connections:
 <% end %>
 <% if ENV['MYSQL_SOCK'] %>
       socket: "<%= ENV['MYSQL_SOCK'] %>"
+<% if ENV['tidb'] %>
+      variables:
+          tidb_enable_noop_functions: ON
 <% end %>
     arunit2:
       username: <%= ENV["MYSQL_USER"] || 'rails' %>
@@ -63,6 +66,9 @@ connections:
 <% end %>
 <% if ENV['MYSQL_SOCK'] %>
       socket: "<%= ENV['MYSQL_SOCK'] %>"
+<% if ENV['tidb'] %>
+      variables:
+          tidb_enable_noop_functions: ON
 <% end %>
 
   oracle:

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -52,6 +52,7 @@ connections:
 <% if ENV['tidb'] %>
       variables:
           tidb_enable_noop_functions: ON
+          tidb_skip_isolation_level_check: 1
 <% end %>
     arunit2:
       username: <%= ENV["MYSQL_USER"] || 'rails' %>
@@ -69,6 +70,7 @@ connections:
 <% if ENV['tidb'] %>
       variables:
           tidb_enable_noop_functions: ON
+          tidb_skip_isolation_level_check: 1
 <% end %>
 
   oracle:

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -5,6 +5,7 @@ require "models/college"
 require "models/course"
 require "models/professor"
 require "models/other_dog"
+require_relative "./savepoint_patch"
 
 module ARTest
   def self.connection_name

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -5,7 +5,7 @@ require "models/college"
 require "models/course"
 require "models/professor"
 require "models/other_dog"
-require_relative "./savepoint_patch"
+require_relative "./savepoint_patch" if ENV['tidb'].present?
 
 module ARTest
   def self.connection_name

--- a/activerecord/test/support/savepoint_patch.rb
+++ b/activerecord/test/support/savepoint_patch.rb
@@ -3,4 +3,16 @@ ActiveRecord::ConnectionAdapters::Mysql2Adapter.class_eval do
   def supports_savepoints?
     false
   end
+
+  def supports_foreign_keys?
+    false
+  end
+
+  def supports_bulk_alter?
+    false
+  end
+
+  def supports_advisory_locks?
+    false
+  end
 end

--- a/activerecord/test/support/savepoint_patch.rb
+++ b/activerecord/test/support/savepoint_patch.rb
@@ -19,4 +19,11 @@ ActiveRecord::ConnectionAdapters::Mysql2Adapter.class_eval do
   def supports_optimizer_hints?
     false
   end
+
+  def transaction_isolation_levels
+    {
+      read_committed:   "READ COMMITTED",
+      repeatable_read:  "REPEATABLE READ"
+    }
+  end
 end

--- a/activerecord/test/support/savepoint_patch.rb
+++ b/activerecord/test/support/savepoint_patch.rb
@@ -1,0 +1,6 @@
+require 'active_record/connection_adapters/mysql2_adapter'
+ActiveRecord::ConnectionAdapters::Mysql2Adapter.class_eval do 
+  def supports_savepoints?
+    false
+  end
+end

--- a/activerecord/test/support/savepoint_patch.rb
+++ b/activerecord/test/support/savepoint_patch.rb
@@ -15,4 +15,8 @@ ActiveRecord::ConnectionAdapters::Mysql2Adapter.class_eval do
   def supports_advisory_locks?
     false
   end
+
+  def supports_optimizer_hints?
+    false
+  end
 end

--- a/tidb_activerecord_testing.sh
+++ b/tidb_activerecord_testing.sh
@@ -11,4 +11,4 @@ echo "Bundle install"
 bundle install
 
 echo "Setup database for testing"
-cd activerecord && bundle exec rake db:mysql:build && bundle exec rake test:mysql2
+cd activerecord && bundle exec rake db:mysql:rebuild && bundle exec rake test:mysql2

--- a/tidb_activerecord_testing.sh
+++ b/tidb_activerecord_testing.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-bundle config set --local path '.bundle' 
+bundle config set --local path '/tmp/buildkite-cache' 
 
 echo "Setup gem mirror"
 bundle config mirror.https://rubygems.org https://gems.ruby-china.com 

--- a/tidb_activerecord_testing.sh
+++ b/tidb_activerecord_testing.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eo pipefail
+
+bundle config set --local path '.bundle' 
+
+echo "Setup gem mirror"
+bundle config mirror.https://rubygems.org https://gems.ruby-china.com 
+
+echo "Bundle install"
+bundle install
+
+echo "Setup database for testing"
+cd activerecord && bundle exec rake db:mysql:build && bundle exec rake test:mysql2


### PR DESCRIPTION
### Summary

This pull request to `7-0-stable` branch cherry-picks commits from pingcap/rails main branch to pingcap/rails 7-0-stable branch to prepare ActiveRecord TiDB Adapter 7.0.z support.

### Other Information

This pull request has been made as follows.
Cherry-pick these 66 commits into 7-0-stable branch


- Created these two git remote
```shell
% git remote -v
origin	git@github.com:yahonda/rails.git (fetch)
origin	git@github.com:yahonda/rails.git (push)
upstream	git@github.com:rails/rails.git (fetch)
upstream	git@github.com:rails/rails.git (push)
```

- Found commits only created at pingcap/rails main branch compared with rails/rails main branch
```shell
% git log upstream/main..pingcap/main --oneline --no-merges
c8cbedd73b (origin/use_tidb_adapter_supports_foreign_keys) Revert "[tidb] skip fail foreign_key test"
176d31aded fix config.yml
5d37ca8f72 [tidb] fix tests
4a92e85e4c [tidb] fix statement_cache_test
15f181f3d1 [tidb] fix has_one_associations_test
d31c59dc6a [tidb] add building status badge
a2d2db8566 [tidb] fix statement_cache_test
f50b7c857d [tidb] fix uniqueness_validations_test
07fe4465f9 [tidb] fix tests
8883c40e73 [tidb] fix collation issue
9dd1b7d044 [tidb] fix test/cases/associations/eager_test.rb
e16df2e2de [tidb] fix lots of test
63e9a263f0 [tidb] fix schema_test
db6996387e [tidb] fix adapter test
8429299d0c [tidb] fix virtual_column_test
4d57aa0eb9 [tidb] fix tests
8c1f7208f4 [tidb] fix calculations_test
fec0da9eb3 [tidb] fix tests
08939e5ae0 [tidb] fix tests
cc3cc247e0 [tidb] fix tests
8e54d330eb [tidb] fix tests
1c3489efeb [tidb] fix tests
11c680cbf0 [tidb] fix tests
56c2318a8b [tidb] fix tests
116407a2f0 [tidb] fix fixtures_test
a2811f3589 [tidb] fix tests
c1926dce98 [tidb] patch for tidb
251fa85e2f [tidb] fix typo
328a20bbd2 [tidb] fix reflection_test
896a600693 [tidb] fix primary_keys_test
92f2d2a8e9 [tidb] fix schema_test
e7f6ad0e6e [tidb] fix schema_migrations_test
c060fc46e0 [tidb] fix ar_schema_test
1bab1d4900 [tidb] fix rename_table_test
9f6f3d524d [tidb] fix references_statements_test
f5c067d0c2 [tidb] fix mysql 8 testing
a1dd99beba [tidb] fix invertible_migration_test
99633259f9 [tidb] fix compatibility_test
bcd5a002ff [tidb] fix v
5dc88a2a09 [tidb] fix references_index_test
546398eb89 [tidb] fix create_join_table_test
a194cf4071 [tidb] fix mysql2_adapter_test
376c7b87ca [tidb] fix table_options_test
08e5e029bf [tidb] fix schema_migrations_test
1dc78b965c [tidb] fix timestamp_test
8e00a3f957 [tidb] fix columns_test
37bd9edc87 [tidb] fix migration_test
d6341314db [tidb] fix active_schema_test
56949a3037 [tidb] fix migration_test
d6431b2d2c [tidb] fix adapter_test
92ba11b2dd [tidb] fix compatibility_test
102ee6741f [tidb] skip nested_deadlock_test
4612e1f67d [tidb] fix transactions_test
a0f02c76c1 [tidb] tmp fix mysql2_adapter_prevent_writes_test
5f29ce490a [tidb] fix updatable view test
1f68df160a [tidb] fix savepoint testing
d4fd793714 Revert "[tidb] use localhost"
b574bdbf5d [tidb] use localhost
ca24a45889 [tidb] skip stored procedures
665833046a [tidb] skip fail foreign_key test
7bbd1005af [tidb] use buildkite cache
983415bcb9 rebuild database for every testing
0dfcac9e49 config mysql port
74e38fbf26 use bash for speed
0a5469e985 (pingcap/setup_tidb_testing) setup buildkite pipeline
cfd8035f38 setup tidb testing
%
```

- Execute `git cherry-pick <commit hash>` from the bottom of the list `cfd8035f38` to the top `c8cbedd73b`

- These 4 conflicts are resolved.
176d31aded fix config.yml conflicts with https://github.com/pingcap/rails/commit/176d31aded
92ba11b2dd [tidb] fix compatibility_test conflicts with https://github.com/rails/rails/commit/1fe808f5d217726fcb738375fe6aa6ee407d8058
1f68df160a [tidb] fix savepoint testing conflicts with https://github.com/rails/rails/commit/c91a8135c77619711b245e4bcbff72f34edfc3a7
cfd8035f38 setup tidb testing conflicts with https://github.com/rails/rails/commit/c91a8135c77619711b245e4bcbff72f34edfc3a7
