### PR TITLE
Skip test_with_lock_configures_transaction until savepoint supported

### DIFF
--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -743,6 +743,7 @@ unless in_memory_db?
     end
 
     def test_with_lock_configures_transaction
+      skip("TiDB issue: https://github.com/pingcap/tidb/issues/6840") if ENV['tidb'].present?
       person = Person.find 1
       Person.transaction do
         outer_transaction = Person.connection.transaction_manager.current_transaction


### PR DESCRIPTION
### Summary

This pull request skips test_with_lock_configures_transaction until savepoint supported.

To address one of error at https://github.com/pingcap/activerecord-tidb-adapter/pull/36
```
2022-03-29T00:44:48.7286786Z Error:
2022-03-29T00:44:48.7287127Z PessimisticLockingTest#test_with_lock_configures_transaction:
2022-03-29T00:44:48.7288035Z ActiveRecord::StatementInvalid: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 9 near "SAVEPOINT active_record_1" 
```


### Other Information

This pull request target is pingcap/rails main branch, will open a backport pull request to pingcap/rails 7-0-branch once it is merged.