### PR TITLE
InsertAll#teardown to delete all of ships table to workaround duplicate entry error

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -23,6 +23,7 @@ class InsertAllTest < ActiveRecord::TestCase
 
   def teardown
     Arel::Table.engine = ActiveRecord::Base
+    Ship.delete_all
   end
 
   def test_insert


### PR DESCRIPTION
### Summary

This pull request addresses errors at InsertAll tests which is due to TiDB does not support savepoint.

```ruby
Error:
InsertAllTest#test_upsert_all_does_not_implicitly_set_timestamps_on_update_when_model_record_timestamps_is_true_but_overridden:
ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '101' for key 'PRIMARY'
```

### Other Information

This pull request target is pingcap/rails main branch, will open a backport pull request to pingcap/rails 7-0-branch once it is merged.