### PR TITLE
`Liquid.delete_all` at `StatementCacheTest#setup`

### DIFF
--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -11,6 +11,7 @@ module ActiveRecord
   class StatementCacheTest < ActiveRecord::TestCase
     def setup
       @connection = ActiveRecord::Base.connection
+      Liquid.delete_all
     end
 
     def teardown


### PR DESCRIPTION
### Summary

This pull request runs`Liquid.delete_all` at `StatementCacheTest#setup` to workaround this failure.
https://github.com/pingcap/activerecord-tidb-adapter/runs/5746649046?check_suite_focus=true#step:8:14

```ruby
Failure:
ActiveRecord::StatementCacheTest#test_find_association_does_not_use_statement_cache_if_table_name_is_changed [/home/runner/work/activerecord-tidb-adapter/activerecord-tidb-adapter/vendor/bundle/ruby/2.7.0/bundler/gems/rails-8e88c0ecd838/activerecord/test/cases/statement_cache_test.rb:[15](https://github.com/pingcap/activerecord-tidb-adapter/runs/5746649046?check_suite_focus=true#step:8:15)5]:
Expected #<Liquid id: 1, name: "Posideons Killer", color: nil, pirate_id: 1> to be nil.
```

I assume this record has been created by one of these tests which is outside of `StatementCacheTest`. so `Liquid.delete_all` at `StatementCacheTest#setup` should workaround it.

```ruby
% git grep -n 'Posideons Killer' | grep create
activerecord/test/cases/autosave_association_test.rb:1027:    @parrot = @pirate.parrots.create!(name: "Posideons Killer")
activerecord/test/cases/autosave_association_test.rb:1749:    @child_1 = @pirate.birds.create(name: "Posideons Killer")
activerecord/test/cases/autosave_association_test.rb:1766:    @child_1 = @pirate.parrots.create(name: "Posideons Killer")
activerecord/test/cases/autosave_association_test.rb:1783:    @child_1 = @pirate.parrots.create(name: "Posideons Killer")
activerecord/test/cases/nested_attributes_test.rb:871:    @pirate.birds.create!(name: "Posideons Killer")
activerecord/test/cases/nested_attributes_test.rb:893:    @pirate.parrots.create!(name: "Posideons Killer")
```


### Other Information

This pull request target is pingcap/rails main branch, will open a backport pull request to pingcap/rails 7-0-branch once it is merged.