### PR TITLE
Add `CalculationsTest#setup` to `ShipPart.delete_all`

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -26,6 +26,10 @@ require "support/stubs/strong_parameters"
 class CalculationsTest < ActiveRecord::TestCase
   fixtures :companies, :accounts, :authors, :author_addresses, :topics, :speedometers, :minivans, :books, :posts, :comments
   
+  def setup
+    ShipPart.delete_all
+  end
+
   def teardown
     Company.delete_all
     NumericData.delete_all


### PR DESCRIPTION
### Summary

This pull request Add `CalculationsTest#setup` to `ShipPart.delete_all` to workaroud this failure at #42
https://github.com/pingcap/activerecord-tidb-adapter/runs/5763650474?check_suite_focus=true#step:8:14

```ruby
Failure:
CalculationsTest#test_calculation_with_polymorphic_relation [/home/runner/work/activerecord-tidb-adapter/activerecord-tidb-adapter/vendor/bundle/ruby/2.7.0/bundler/gems/rails-8e88c0ecd838/activerecord/test/cases/calculations_test.rb:1007]:
Expected: 19
  Actual: [15](https://github.com/pingcap/activerecord-tidb-adapter/runs/5763650474?check_suite_focus=true#step:8:15)1
```
