### PR TITLE
Re-run skipped tests due to index method differences

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -84,7 +84,6 @@ module ActiveRecord
     end
 
     def test_indexes
-      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       idx_name = "accounts_idx"
 
       indexes = @connection.indexes("accounts")

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -27,7 +27,6 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_add_index
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     expected = "CREATE INDEX `index_people_on_last_name` ON `people` (`last_name`)"
     assert_equal expected, add_index(:people, :last_name, length: nil)
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -7,7 +7,6 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
   self.use_transactional_tests = false
 
   def test_renaming_index_on_foreign_key
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     connection.add_index "engines", "car_id"
     connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
 

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -71,7 +71,6 @@ module ActiveRecord
       end
 
       def test_dump_indexes
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         index_a_name = "index_key_tests_on_snack"
         index_b_name = "index_key_tests_on_pizza"
         index_c_name = "index_key_tests_on_awesome"

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1120,7 +1120,6 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   end
 
   def test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     Bird.connection.add_index :birds, :name, unique: true
 
     3.times { |i| @pirate.birds.create(name: "unique_birds_#{i}") }

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -244,7 +244,6 @@ module ActiveRecord
     end
 
     def test_exception_on_removing_index_without_column_option
-      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       index_definition = ["horses", [:name, :color]]
       migration1 = RemoveIndexMigration1.new
       migration1.migrate(:up)
@@ -495,7 +494,6 @@ module ActiveRecord
     end
 
     def test_migrate_revert_add_index_without_name_on_expression
-      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       InvertibleMigration.new.migrate(:up)
       RevertNonNamedExpressionIndexMigration.new.migrate(:up)
 

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -94,7 +94,6 @@ module ActiveRecord
       end
 
       def test_rename_column_with_an_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_column "test_models", :hat_name, :string
         add_index :test_models, :hat_name
 
@@ -136,7 +135,6 @@ module ActiveRecord
       end
 
       def test_remove_column_with_multi_column_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         # MariaDB starting with 10.2.8
         # Dropping a column that is part of a multi-column UNIQUE constraint is not permitted.
         skip if current_adapter?(:Mysql2Adapter) && connection.mariadb? && connection.database_version >= "10.2.8"
@@ -305,7 +303,6 @@ module ActiveRecord
       end
 
       def test_column_with_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table "my_table", force: true do |t|
           t.string :item_number, index: true
         end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -29,7 +29,6 @@ module ActiveRecord
       end
 
       def test_migration_doesnt_remove_named_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, name: "custom_index_name"
 
         migration = Class.new(ActiveRecord::Migration[4.2]) {
@@ -45,7 +44,6 @@ module ActiveRecord
       end
 
       def test_migration_does_remove_unnamed_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :bar
 
         migration = Class.new(ActiveRecord::Migration[4.2]) {
@@ -284,7 +282,6 @@ module ActiveRecord
         }.new
 
         ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
         assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
       ensure
@@ -292,7 +289,6 @@ module ActiveRecord
       end
 
       def test_change_table_with_polymorphic_reference_uses_all_column_names_in_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         migration = Class.new(ActiveRecord::Migration[6.0]) {
           def migrate(x)
             change_table :testings do |t|
@@ -309,7 +305,6 @@ module ActiveRecord
       end
 
       def test_create_join_table_with_polymorphic_reference_uses_all_column_names_in_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         migration = Class.new(ActiveRecord::Migration[6.0]) {
           def migrate(x)
             create_join_table :more, :testings do |t|
@@ -328,7 +323,6 @@ module ActiveRecord
       end
 
       def test_polymorphic_add_reference_uses_all_column_names_in_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         migration = Class.new(ActiveRecord::Migration[6.0]) {
           def migrate(x)
             add_reference :testings, :widget, polymorphic: true, index: true

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -73,7 +73,6 @@ module ActiveRecord
       end
 
       def test_create_join_table_with_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_join_table :artists, :musics do |t|
           t.index [:artist_id, :music_id]
         end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -82,7 +82,6 @@ module ActiveRecord
       end
 
       def test_add_index_which_already_exists_does_not_raise_error_with_option
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index(table_name, "foo")
 
         assert_nothing_raised do
@@ -105,7 +104,6 @@ module ActiveRecord
       end
 
       def test_remove_index_which_does_not_exist_doesnt_raise_with_option
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index(table_name, "foo")
 
         connection.remove_index(table_name, "foo")
@@ -120,7 +118,6 @@ module ActiveRecord
       end
 
       def test_remove_index_with_name_which_does_not_exist_doesnt_raise_with_option
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index(table_name, [:foo], name: "foo")
 
         assert connection.index_exists?(table_name, :foo, name: "foo")
@@ -139,7 +136,6 @@ module ActiveRecord
       end
 
       def test_index_symbol_names
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index table_name, :foo, name: :symbol_index_name
         assert connection.index_exists?(table_name, :foo, name: :symbol_index_name)
 
@@ -148,7 +144,6 @@ module ActiveRecord
       end
 
       def test_index_exists
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo
 
         assert connection.index_exists?(:testings, :foo)
@@ -156,35 +151,30 @@ module ActiveRecord
       end
 
       def test_index_exists_on_multiple_columns
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, [:foo, :bar]
 
         assert connection.index_exists?(:testings, [:foo, :bar])
       end
 
       def test_index_exists_with_custom_name_checks_columns
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, [:foo, :bar], name: "my_index"
         assert connection.index_exists?(:testings, [:foo, :bar], name: "my_index")
         assert_not connection.index_exists?(:testings, [:foo], name: "my_index")
       end
 
       def test_valid_index_options
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         assert_raise ArgumentError do
           connection.add_index :testings, :foo, unqiue: true
         end
       end
 
       def test_unique_index_exists
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, unique: true
 
         assert connection.index_exists?(:testings, :foo, unique: true)
       end
 
       def test_named_index_exists
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, name: "custom_index_name"
 
         assert connection.index_exists?(:testings, :foo)
@@ -193,7 +183,6 @@ module ActiveRecord
       end
 
       def test_remove_named_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, :foo, name: "index_testings_on_custom_index_name"
 
         assert connection.index_exists?(:testings, :foo)
@@ -205,14 +194,12 @@ module ActiveRecord
       end
 
       def test_add_index_attribute_length_limit
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index :testings, [:foo, :bar], length: { foo: 10, bar: nil }
 
         assert connection.index_exists?(:testings, [:foo, :bar])
       end
 
       def test_add_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.add_index("testings", "last_name")
         connection.remove_index("testings", "last_name")
 

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -18,7 +18,6 @@ module ActiveRecord
       end
 
       def test_creates_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name do |t|
           t.references :foo, index: true
         end
@@ -27,7 +26,6 @@ module ActiveRecord
       end
 
       def test_creates_index_by_default_even_if_index_option_is_not_passed
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name do |t|
           t.references :foo
         end
@@ -44,7 +42,6 @@ module ActiveRecord
       end
 
       def test_creates_index_with_options
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name do |t|
           t.references :foo, index: { name: :index_testings_on_yo_momma }
           t.references :bar, index: { unique: true }
@@ -56,7 +53,6 @@ module ActiveRecord
 
       unless current_adapter? :OracleAdapter
         def test_creates_polymorphic_index
-          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name do |t|
             t.references :foo, polymorphic: true, index: true
           end
@@ -65,7 +61,6 @@ module ActiveRecord
         end
 
         def test_creates_polymorphic_index_with_custom_name
-          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name do |t|
             t.references :foo, polymorphic: true, index: { name: :testings_foo_index }
           end
@@ -75,7 +70,6 @@ module ActiveRecord
       end
 
       def test_creates_index_for_existing_table
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name
         connection.change_table table_name do |t|
           t.references :foo, index: true
@@ -85,7 +79,6 @@ module ActiveRecord
       end
 
       def test_creates_index_for_existing_table_even_if_index_option_is_not_passed
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         connection.create_table table_name
         connection.change_table table_name do |t|
           t.references :foo
@@ -105,7 +98,6 @@ module ActiveRecord
 
       unless current_adapter? :OracleAdapter
         def test_creates_polymorphic_index_for_existing_table
-          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name
           connection.change_table table_name do |t|
             t.references :foo, polymorphic: true, index: true
@@ -115,7 +107,6 @@ module ActiveRecord
         end
 
         def test_creates_polymorphic_index_for_existing_table_with_custom_name
-          skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
           connection.create_table table_name
           connection.change_table table_name do |t|
             t.references :foo, polymorphic: true, index: { name: :testings_foo_index }

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -45,13 +45,11 @@ module ActiveRecord
       end
 
       def test_create_reference_id_index_even_if_index_option_is_not_passed
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :user
         assert index_exists?(table_name, :user_id)
       end
 
       def test_creates_polymorphic_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :taggable, polymorphic: true, index: true
         assert index_exists?(table_name, [:taggable_type, :taggable_id])
       end
@@ -77,13 +75,11 @@ module ActiveRecord
       end
 
       def test_creates_named_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id" }
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id")
       end
 
       def test_creates_named_unique_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_reference table_name, :tag, index: { name: "index_taggings_on_tag_id", unique: true }
         assert index_exists?(table_name, :tag_id, name: "index_taggings_on_tag_id", unique: true)
       end
@@ -122,7 +118,6 @@ module ActiveRecord
       end
 
       def test_deletes_polymorphic_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         with_polymorphic_column do
           remove_reference table_name, :supplier, polymorphic: true
           assert_not index_exists?(table_name, [:supplier_id, :supplier_type])

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -50,7 +50,6 @@ module ActiveRecord
       end
 
       def test_rename_table_with_an_index
-        skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
         add_index :test_models, :url
 
         rename_table :test_models, :octopi

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1126,7 +1126,6 @@ end
 
 class ReservedWordsMigrationTest < ActiveRecord::TestCase
   def test_drop_index_from_table_named_values
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     connection = Person.connection
     connection.create_table :values, force: true do |t|
       t.integer :value
@@ -1143,7 +1142,6 @@ end
 
 class ExplicitlyNamedIndexMigrationTest < ActiveRecord::TestCase
   def test_drop_index_by_name
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     connection = Person.connection
     connection.create_table :values, force: true do |t|
       t.integer :value

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -164,7 +164,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_columns_in_right_order
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_index/).first.strip
     if current_adapter?(:Mysql2Adapter)
       if ActiveRecord::Base.connection.supports_index_sort_order?
@@ -180,7 +179,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_partial_indices
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_partial_index/).first.strip
     if ActiveRecord::Base.connection.supports_partial_index?
       assert_equal 't.index ["firm_id", "type"], name: "company_partial_index", where: "(rating > 10)"', index_definition
@@ -190,7 +188,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_sort_order
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*_name_and_rating/).first.strip
     if ActiveRecord::Base.connection.supports_index_sort_order?
       assert_equal 't.index ["name", "rating"], name: "index_companies_on_name_and_rating", order: :desc', index_definition
@@ -200,7 +197,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dumps_index_length
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*_name_and_description/).first.strip
     if current_adapter?(:Mysql2Adapter)
       assert_equal 't.index ["name", "description"], name: "index_companies_on_name_and_description", length: 10', index_definition
@@ -301,7 +297,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
 
     def test_schema_dumps_index_type
-      skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
       output = dump_table_schema "key_tests"
       assert_match %r{t\.index \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext$}, output
       assert_match %r{t\.index \["pizza"\], name: "index_key_tests_on_pizza"$}, output

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -488,7 +488,6 @@ class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
   end
 
   def test_index_is_created_for_both_timestamps
-    skip("TiDB issue: https://github.com/pingcap/tidb/issues/26110") if ENV['tidb'].present?
     ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
       t.timestamps null: true, index: true
     end


### PR DESCRIPTION
### Summary

We can run these skipped tests because of the following reasons:

* https://github.com/pingcap/tidb/issues/26110 has been addressed since TiDB v5.2.0 or higher via https://github.com/pingcap/tidb/commit/1641b3411d663eb67464a34882a3f222b67cea8d

* ActiveRecord TiDB Adapter has its own `index` method to workaround https://github.com/pingcap/tidb/issues/26110
for older versions of TiDB

### Other Information

https://github.com/pingcap/activerecord-tidb-adapter/pull/54 aims to use the original index method at ActiveRecord TiDB adapter.
